### PR TITLE
Instruction name to code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ $(NAME): $(OBJ)
 	$(CC) -o $@ $^
 
 $(BUILD_DIR)%.o: $(SRC_DIR)%.c
+	$(shell mkdir -p $(BUILD_DIR))
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:

--- a/src/TestOperation.c
+++ b/src/TestOperation.c
@@ -1,7 +1,7 @@
 #define NUM_OPERATIONS 28
 #include "arabica.h"
 
-int getFunctionIdFromName(char *functionName) {
+int getFunctionCodeFromName(char *functionName) {
     const char *operations[NUM_OPERATIONS] = {
         "LOAD_VAL",
         "READ_VAR",

--- a/src/arabica.h
+++ b/src/arabica.h
@@ -20,6 +20,7 @@
 // Structures
 typedef struct Instruction {
     char *instruction;
+    char code; // Instruction code stored on 1 byte
     char arguments[ARGUMENTS_MAX_NUM][ARGUMENT_MAX_SIZE];
     int size; // Maybe not needed
 }_Instruction;
@@ -28,7 +29,7 @@ typedef struct Instruction {
 
 // Write project's functions signatures below
 char* getName(int argc, char *argv[]);
-int getFunctionIdFromName(char *functionName);
+int getFunctionCodeFromName(char *functionName);
 void writeHeader(int filedes, int programSize, char programName[PROGRAM_NAME_SIZE]);
 void writeIntegerForCompile(int filedes, int integer);
 void writeStringForCompile(int filedes, char *input);

--- a/src/main.c
+++ b/src/main.c
@@ -19,9 +19,9 @@ int main(int argc, char **argv)
     // char *processName = getName(argc, argv); // get the name of the process
     writeHeader(filedes, 24, programName);
 
-    char load_val = getFunctionIdFromName("LOAD_VAL");
-    char add = getFunctionIdFromName("ADD");
-    char print_val = getFunctionIdFromName("PRINT_VAL");
+    char load_val = getFunctionCodeFromName("LOAD_VAL");
+    char add = getFunctionCodeFromName("ADD");
+    char print_val = getFunctionCodeFromName("PRINT_VAL");
 
     parse_abc("test.abc");
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -34,6 +34,7 @@ _Instruction *parse_abc(char *filename)
         char **splitted_line = split(line, " ");
 
         current_instruction.instruction = my_strdup(trim(splitted_line[0]));
+        current_instruction.code = getFunctionCodeFromName(current_instruction.instruction);
         if (splitted_line[1] != NULL) {
             my_strcpy(current_instruction.arguments[0], trim(splitted_line[1]));
             if (splitted_line[2] != NULL) {
@@ -46,14 +47,15 @@ _Instruction *parse_abc(char *filename)
         current_result_index++;
     }
 
-    int i = 0;
+    // int i = 0;
 
-    while (result[i].instruction != NULL) {
-        printf("Instruction: %s\n", result[i].instruction);
-        printf("Argument 1: %s\n", result[i].arguments[0]);
-        printf("Argument 2: %s\n", result[i].arguments[1]);
-        i++;
-    }
+    // while (result[i].instruction != NULL) {
+    //     printf("Instruction: %s\n", result[i].instruction);
+    //     printf("Code: %d\n", result[i].code);
+    //     printf("Argument 1: %s\n", result[i].arguments[0]);
+    //     printf("Argument 2: %s\n", result[i].arguments[1]);
+    //     i++;
+    // }
 
     return result;
 }


### PR DESCRIPTION
Convert instructions names to code when I parse the .abc file, e.g. LOAD_VAL => 1

Rename function getFunctionIdFromName to getFunctionCodeFromName

Create "build" folder if it does not exist at build with make